### PR TITLE
Changed the length of rxName[6] to rxName[10] in purRxConfigs()

### DIFF
--- a/AffoFly_Transmitter/AffoFly_Transmitter.ino
+++ b/AffoFly_Transmitter/AffoFly_Transmitter.ino
@@ -323,7 +323,7 @@ void putRxConfigs() {
     rxConfig.YawTrim = 0;
     rxConfig.PitchTrim = 0;
     rxConfig.RollTrim = 0;
-    char rxName[6] = "RX ";
+    char rxName[10] = "RX ";
     char rxIdText[3] = "";
     itoa(i, rxIdText, 10);
     if (i < 10) {


### PR DESCRIPTION
The length of rxName[6] should be 10 because strings are concatenated beyond the length of 6.
Also, it needs to be the same length as rxConfig.Name.